### PR TITLE
feat (github/workflows/CICD): added base for for building and pushing Docker image

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,0 +1,39 @@
+name: Build and Push Docker Image
+
+# Make sure to add DockerHub credentials as secrets in your GitHub repository settings (DOCKER_USERNAME and DOCKER_PASSWORD)
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2 # Checks out your repository
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2 # Sets up QEMU for multi-platform builds
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2 # Sets up Docker Buildx
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }} # DockerHub username read from secret
+          password: ${{ secrets.DOCKER_PASSWORD }} # DockerHub password read from secret
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v6.11.0
+        with:
+          context: . # Build context
+          file: ./Dockerfile # Path to the Dockerfile
+          platforms: linux/amd64,linux/arm/v7,linux/arm64 # Target platforms
+          push: true # Push the image to DockerHub
+          tags: carbon2029/dockweb:latest # Docker image tag
+          cache-from: type=gha # Use GitHub Actions cache to speed-up future builds
+          cache-to: type=gha,mode=max # Store cache in GitHub Actions to speed-up future builds


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to automate the process of building and pushing Docker images to DockerHub. The workflow includes the following features:

- Triggers on push to the `main` branch and can be manually triggered.
- Sets up QEMU for multi-platform builds.
- Uses Docker Buildx for building images.
- Logs in to DockerHub using secrets.
- Builds and pushes Docker images for `linux/amd64`, `linux/arm/v7`, and `linux/arm64` platforms.
- Utilizes GitHub Actions cache to speed up future builds.

**Tip:** Ensure that the `main` branch always contains stable code ready for production. Open feature branches like `feature/<featurename>` and merge them back into `main`. Similarly, for fixes, open branches like `fix/<issuefixname>` and merge them back. This way, only stable code is pushed to the image builds.

This workflow serves as a base and can be customized to fit your specific needs.

Make sure to add your DockerHub credentials (`DOCKER_USERNAME` and `DOCKER_PASSWORD`) as secrets in your GitHub repository settings.

Hope you find this contribution useful! 🚀
